### PR TITLE
Healing while asleep

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -67,6 +67,30 @@
 	return ..()
 
 /datum/status_effect/incapacitating/sleeping/tick()
+	var/probability = 10 //probability of heal per tick. 200 ticks in 40 seconds of sleep
+	if((locate(/obj/structure/bed) in owner.loc)) //if in bed +10%
+		probability +=10
+	else
+		if((locate(/obj/structure/table) in owner.loc))//if on a table
+			probability +=5
+	if((locate(/obj/item/bedsheet) in owner.loc))//if under a bedsheet
+		probability +=10
+
+	for(var/i in Cool)
+		if(locate(i) in owner.loc)
+			probability +=5 //from stuff on cool
+			break
+
+	for(var/i in SuperCool)
+		if(locate(i) in owner.loc)
+			probability +=5//from stuff on supercool
+			break
+
+	if(prob(probability))
+		owner.adjustBruteLoss(-1, 0)
+		owner.adjustFireLoss(-1, 0)
+		owner.adjustToxLoss(-1, 0)
+
 	if(owner.getStaminaLoss())
 		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.5 per tick, 10 per 2 seconds
 	if(human_owner && human_owner.drunkenness)


### PR DESCRIPTION
## Changelog
:cl:
add: You now heal while you sleep.
/:cl:

## About The Pull Request
Adds a chance to heal 1 brute, tox, burn damage per tick while you sleep.
the chance depends on 2 factors:
-if you are sleeping on a bed, a table or anywhere else
-if you are covered by a bedsheet, and the coolness of the bedsheet. (normal bedsheets are ok, bedsheets like clown, mime or medical are better and captain/syndie bedsheet gives the best bonus)

## Why It's Good For The Game

Gives actual use to dorms and the ability to survive even if the medbay is fucked.
Sleeping lasts 40 seconds of total incapacitation, so you are trading some health for vulnerability.